### PR TITLE
fix: disallow using duplicate chars for `jumpy.primaryCharset`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
             "properties": {
                 "jumpy.primaryCharset": {
                     "type": "string",
-                    "pattern": "[a-z0-9]",
+                    "pattern": "^(?:([a-z0-9])(?!.*\\1))+$",
+                    "patternErrorMessage": "Please enter unique characters from [a-z0-9].",
                     "default": "qwerasdf1234zxcv",
                     "description": "Set of characters used to create jump key combinations. First letters will occur the closes to the current active line."
                 },

--- a/src/jumpy/char_code.ts
+++ b/src/jumpy/char_code.ts
@@ -45,12 +45,8 @@ function combineElements(arrA: string[], arrB: string[], callback: (s: string) =
         .forEach((elem) => callback(elem.text));
 }
 
-function deduplicate(chars: string[]): string[] {
-    return Array.from(new Set(chars).values());
-}
-
 export function createCharCodeSet(primaryCharacters = DEFAULT_PRIMARY_CHARS): string[] {
-    const primaryChars = deduplicate(primaryCharacters.filter((char) => ALL_ALLOWED_CHARS.includes(char)));
+    const primaryChars = primaryCharacters.filter((char) => ALL_ALLOWED_CHARS.includes(char));
     const secondaryChars = ALL_ALLOWED_CHARS.filter((char) => !primaryChars.includes(char));
 
     const codeSet: string[] = [];


### PR DESCRIPTION
This is an improvement over https://github.com/krnik/vscode-jumpy/commit/6a95264b0f73cc1a835488e572999c9a24299874, since we only need to deduplicate user-provided primary chars, we can restrict the user input when setting `jumpy.primaryCharset`.